### PR TITLE
添加播放器 SDK 对 ESM 规范的支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,4 @@ node_modules
 .cache
 .parcel-cache
 demo/.vitepress/dist
-yarn.lock
-package-lock.json
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -1,6 +1,30 @@
 {
     "name": "jessibuca",
     "version": "1.0.0",
+    "main": "dist/jessibuca.js",
+    "module": "dist/jessibuca.esm.js",
+    "unpkg": "dist/jessibuca.js",
+    "jsdelivr": "dist/jessibuca.js",
+    "types": "dist/jessibuca.d.ts",
+    "files": [
+      "dist",
+      "package.json",
+      "LICENSE",
+      "README.md",
+      "README.en.md"
+    ],
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/jessibuca.d.ts",
+          "default": "./dist/jessibuca.esm.js"
+        },
+        "require": {
+          "types": "./dist/jessibuca.d.ts",
+          "default": "./dist/jessibuca.js"
+        }
+      }
+    },
     "scripts": {
         "build": "npx cross-env NODE_ENV=production rollup -c",
         "build:wasm": "python wasm/make.py --wasm && npm run build && npm run build:demo",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
         "rollup-plugin-replace": "^2.2.0",
         "rollup-plugin-string": "^3.0.0",
         "rollup-plugin-terser": "^7.0.2",
-        "rollup-plugin-worker-inline": "^1.0.6",
         "rollup-plugin-copy": "^3.4.0",
         "servor": "^4.0.2"
     },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,13 +9,13 @@ import json from '@rollup/plugin-json'; // 解析json格式
 import copy from 'rollup-plugin-copy';  // 直接复制文件和文件夹。
 import {terser} from 'rollup-plugin-terser'; // 压缩
 import base64 from 'postcss-base64'; // 图片变成base64
+import packageJson from './package.json';
 
 
 const isProd = process.env.NODE_ENV === 'production';
 
 const baseConfig = {
     output: {
-        format: 'umd',
         sourcemap: !isProd,
     },
     plugins: [
@@ -72,10 +72,19 @@ const baseConfig = {
 export default [
     {
         input: 'src/jessibuca.js',
-        output: {
-            name: 'jessibuca',
-            file: isProd ? 'dist/jessibuca.js' : 'demo/public/jessibuca.js',
-        },
+        output: [
+            {
+                name: 'jessibuca',
+                file: isProd ? packageJson.main : 'demo/public/jessibuca.js',
+                format: 'umd',
+                ...baseConfig.output
+            },
+            {
+                file: isProd ? packageJson.module : 'demo/public/jessibuca.js',
+                format: 'esm',
+                ...baseConfig.output
+            }
+        ],
         plugins: [
             postcss({
                 plugins: [
@@ -99,16 +108,14 @@ export default [
         output: {
             name: 'decoder',
             file: isProd ? 'dist/decoder.js' : 'demo/public/decoder.js',
+            ...baseConfig.output
         },
         plugins: [],
     }
 ].map(config => {
     return {
         input: config.input,
-        output: {
-            ...baseConfig.output,
-            ...config.output,
-        },
+        output: config.output,
         plugins: [...baseConfig.plugins, ...config.plugins],
     };
 });


### PR DESCRIPTION
- 新增 ESM 规范的支持，`npm run build` 将会多产出一个 ESM 规范的 SDK
- 恢复`package-lock.json` 以及 `yarn.lock` 文件的版本管理
- 移除未使用的依赖包 `rollup-plugin-worker-inline` 解决 `npm instatll` 报红的问题